### PR TITLE
PR: Initial work for supporting GPU VA

### DIFF
--- a/compute-only-sample/coscommon/CosGpuCommand.h
+++ b/compute-only-sample/coscommon/CosGpuCommand.h
@@ -33,7 +33,12 @@ struct GpuCommandBufferHeader
     {
         struct
         {
-            UINT    m_swCommandBuffer   : 1;
+            UINT    m_swCommandBuffer       : 1;
+#if GPUVA
+
+            UINT    m_gpuVaCommandBuffer    : 1;
+
+#endif
         };
 
         UINT        m_value;

--- a/compute-only-sample/coskmd/CosKmd.h
+++ b/compute-only-sample/coskmd/CosKmd.h
@@ -61,5 +61,29 @@ const int C_COSD_GPU_ENGINE_COUNT = 1;
 
 #endif
 
+#if GPUVA
+
+//
+// The DDI_N indicates DDI call sequence during adapter initialization
+//
+
+#define GPUVA_INIT_DDI_1    1
+#define GPUVA_INIT_DDI_2    1
+#define GPUVA_INIT_DDI_3    1
+#define GPUVA_INIT_DDI_4    1
+#define GPUVA_INIT_DDI_5    1
+#define GPUVA_INIT_DDI_6    1
+#define GPUVA_INIT_DDI_7    1
+#define GPUVA_INIT_DDI_8    1
+
+//
+// The current GPUVA implementation declares 1 aperture segment
+// so the implicit system memory segment (created by OS) is 2.
+//
+
+#define IMPLICIT_SYSTEM_MEMORY_SEGMENT_ID   2
+
+#endif
+
 // #define GPU_CACHE_WORKAROUND 1
 

--- a/compute-only-sample/coskmd/CosKmd.vcxproj
+++ b/compute-only-sample/coskmd/CosKmd.vcxproj
@@ -59,6 +59,7 @@
     <ClInclude Include="CosKmdDevice.h" />
     <ClInclude Include="CosKmdGlobal.h" />
     <ClInclude Include="CosKmdMetaCommand.h" />
+    <ClInclude Include="CosKmdProcess.h" />
     <ClInclude Include="CosKmdResource.h" />
     <ClInclude Include="CosKmdSoftAdapter.h" />
     <ClInclude Include="CosKmdUtil.h" />
@@ -192,7 +193,7 @@
       <WarningLevel>Level4</WarningLevel>
       <AdditionalUsingDirectories>
       </AdditionalUsingDirectories>
-      <PreprocessorDefinitions>MLMC=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MLMC=0;GPUVA=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++17 %(AdditionalOptions)</AdditionalOptions>
       <SupportJustMyCode>false</SupportJustMyCode>
     </ClCompile>

--- a/compute-only-sample/coskmd/CosKmdAdapter.h
+++ b/compute-only-sample/coskmd/CosKmdAdapter.h
@@ -41,6 +41,9 @@ typedef struct _COSDMABUFSTATE
             UINT    m_bPreempted        : 1;
             UINT    m_bReset            : 1;
             UINT    m_bCompleted        : 1;
+#if GPUVA
+            UINT    m_bGpuVaCommandBuffer : 1;
+#endif
         };
 
         UINT        m_Value;
@@ -50,7 +53,13 @@ typedef struct _COSDMABUFSTATE
 typedef struct _COSDMABUFINFO
 {
     PBYTE                       m_pDmaBuffer;
-    LARGE_INTEGER               m_DmaBufferPhysicalAddress;
+    union
+    {
+#if GPUVA
+        D3DGPU_VIRTUAL_ADDRESS  m_DmaBufferGpuVa;
+#endif
+        LARGE_INTEGER           m_DmaBufferPhysicalAddress;
+    };
     UINT                        m_DmaBufferSize;
     COSDMABUFSTATE              m_DmaBufState;
 } COSDMABUFINFO;
@@ -286,6 +295,11 @@ protected:
 
     virtual void ProcessRenderBuffer(COSDMABUFSUBMISSION * pDmaBufSubmission) = 0;
     virtual void ProcessHWRenderBuffer(COSDMABUFSUBMISSION * pDmaBufSubmission) = 0;
+#if GPUVA
+
+    virtual void ProcessGpuVaRenderBuffer(COSDMABUFSUBMISSION * pDmaBufSubmission) = 0;
+
+#endif
 
 private:
 
@@ -527,3 +541,14 @@ void MoveToNextCommand(TypeCur pCurCommand, TypeNext &pNextCommand)
     pNextCommand = (TypeNext)(pCurCommand + 1);
 }
 
+#if GPUVA
+
+#define COS_GPU_VA_BIT_COUNT        0x20
+#define COS_PAGE_TABLE_LEVEL_COUNT  2
+
+#define COS_PAGE_TABLE_SIZE         (4*PAGE_SIZE)
+
+#define COSD_APERTURE_SEGMENT_BASE_ADDRESS  0xC0000000
+#define COSD_APERTURE_SEGMENT_SIZE          16*1024*1024
+
+#endif

--- a/compute-only-sample/coskmd/CosKmdContext.h
+++ b/compute-only-sample/coskmd/CosKmdContext.h
@@ -39,6 +39,13 @@ protected:
 
     DXGK_CREATECONTEXTFLAGS m_Flags;
 
+#if GPUVA
+
+    D3DGPU_PHYSICAL_ADDRESS m_rootPageTableAddress;
+    UINT                    m_numRootPageTableEntries;
+
+#endif
+
 public:
 
     UINT
@@ -71,6 +78,14 @@ public:
     NTSTATUS
         RenderKm(
             INOUT_PDXGKARG_RENDER   pRender);
+
+#if GPUVA
+
+    VOID
+        SetRootPageTable(
+            IN_CONST_PDXGKARG_SETROOTPAGETABLE  pSetPageTable);
+
+#endif
 
 public: // PAGED
 

--- a/compute-only-sample/coskmd/CosKmdDdi.cpp
+++ b/compute-only-sample/coskmd/CosKmdDdi.cpp
@@ -199,6 +199,7 @@ NTSTATUS __stdcall CosKmdDdi::DdiGetStandardAllocationDriverData(
     return pCosKmdAdapter->GetStandardAllocationDriverData(pGetStandardAllocationDriverData);
 }
 
+#if GPUVA
 
 NTSTATUS
 __stdcall
@@ -213,6 +214,29 @@ CosKmdDdi::DdiSubmitCommandVirtual(
     return pCosKmdAdapter->SubmitCommandVirtual(pSubmitCommandVirtual);
 }
 
+SIZE_T
+__stdcall
+CosKmdDdi::DdiGetRootPageTableSize(
+    IN_CONST_HANDLE                     /*hAdapter*/,
+    INOUT_PDXGKARG_GETROOTPAGETABLESIZE /*pArgs*/)
+{
+    return COS_PAGE_TABLE_SIZE;
+}
+
+VOID
+__stdcall
+CosKmdDdi::DdiSetRootPageTable(
+    IN_CONST_HANDLE                     /*hAdapter*/,
+    IN_CONST_PDXGKARG_SETROOTPAGETABLE  pSetPageTable)
+{
+    CosKmContext  *pCosKmContext = CosKmContext::Cast(pSetPageTable->hContext);
+
+    DbgPrintEx(DPFLTR_IHVVIDEO_ID, DPFLTR_TRACE_LEVEL, "%s hContext=%lx\n", __FUNCTION__, pSetPageTable->hContext);
+
+    return pCosKmContext->SetRootPageTable(pSetPageTable);
+}
+
+#endif
 
 NTSTATUS
 __stdcall

--- a/compute-only-sample/coskmd/CosKmdDdi.h
+++ b/compute-only-sample/coskmd/CosKmdDdi.h
@@ -80,6 +80,18 @@ public:
             IN_CONST_HANDLE                         hAdapter,
             IN_CONST_PDXGKARG_SUBMITCOMMANDVIRTUAL  pSubmitCommandVirtual);
 
+    static VOID
+        __stdcall
+        CosKmdDdi::DdiSetRootPageTable(
+            IN_CONST_HANDLE                     hAdapter,
+            IN_CONST_PDXGKARG_SETROOTPAGETABLE  pSetPageTable);
+
+    static SIZE_T
+        __stdcall
+        CosKmdDdi::DdiGetRootPageTableSize(
+            IN_CONST_HANDLE                     hAdapter,
+            INOUT_PDXGKARG_GETROOTPAGETABLESIZE pArgs);
+
     static NTSTATUS
         __stdcall
         DdiPreemptCommand(

--- a/compute-only-sample/coskmd/CosKmdDevice.cpp
+++ b/compute-only-sample/coskmd/CosKmdDevice.cpp
@@ -8,6 +8,7 @@
 #include "CosKmdAllocation.h"
 #include "CosKmdUtil.h"
 
+// GPUVA_INIT_DDI_7
 NTSTATUS __stdcall CosKmDevice::DdiCreateDevice(
     IN_CONST_HANDLE hAdapter,
     INOUT_PDXGKARG_CREATEDEVICE pCreateDevice)
@@ -19,6 +20,14 @@ NTSTATUS __stdcall CosKmDevice::DdiCreateDevice(
         COS_LOG_LOW_MEMORY("Failed to allocate CosKmDevice.");
         return STATUS_NO_MEMORY;
     }
+
+#if GPUVA
+
+    CosKmDevice *   pCosKmDevice = (CosKmDevice *)pCreateDevice->hDevice;
+
+    pCosKmDevice->m_pKmdProcess = (CosKmdProcess *)pCreateDevice->hKmdProcess;
+
+#endif
 
     return STATUS_SUCCESS;
 }

--- a/compute-only-sample/coskmd/CosKmdDevice.h
+++ b/compute-only-sample/coskmd/CosKmdDevice.h
@@ -3,6 +3,7 @@
 #include "CosKmd.h"
 
 class CosKmAdapter;
+struct CosKmdProcess;
 
 class CosKmDevice
 {
@@ -33,6 +34,12 @@ private:
 
     DXGK_CREATEDEVICEFLAGS  m_Flags;
     HANDLE                  m_hRTDevice;
+
+#if GPUVA
+
+    CosKmdProcess *         m_pKmdProcess;
+
+#endif
 
 public:
 

--- a/compute-only-sample/coskmd/CosKmdGlobal.cpp
+++ b/compute-only-sample/coskmd/CosKmdGlobal.cpp
@@ -309,10 +309,16 @@ NTSTATUS CosKmdGlobal::DriverEntry(__in IN DRIVER_OBJECT* pDriverObject, __in IN
 
     DriverInitializationData.DxgkDdiGetNodeMetadata = CosKmdDdi::DdiGetNodeMetadata;
 
+#if GPUVA
+
     DriverInitializationData.DxgkDdiSubmitCommandVirtual = CosKmdDdi::DdiSubmitCommandVirtual;
+    DriverInitializationData.DxgkDdiSetRootPageTable = CosKmdDdi::DdiSetRootPageTable;
+    DriverInitializationData.DxgkDdiGetRootPageTableSize = CosKmdDdi::DdiGetRootPageTableSize;
 
     DriverInitializationData.DxgkDdiCreateProcess = CosKmdDdi::DdiCreateProcess;
     DriverInitializationData.DxgkDdiDestroyProcess = CosKmdDdi::DdiDestroyProcess;
+
+#endif
 
     DriverInitializationData.DxgkDdiCalibrateGpuClock = CosKmdDdi::DdiCalibrateGpuClock;
     DriverInitializationData.DxgkDdiSetStablePowerState = CosKmdDdi::DdiSetStablePowerState;

--- a/compute-only-sample/coskmd/CosKmdProcess.h
+++ b/compute-only-sample/coskmd/CosKmdProcess.h
@@ -1,0 +1,7 @@
+#pragma once
+
+struct CosKmdProcess
+{
+    int m_dummy;
+};
+

--- a/compute-only-sample/coskmd/CosKmdSoftAdapter.cpp
+++ b/compute-only-sample/coskmd/CosKmdSoftAdapter.cpp
@@ -171,6 +171,19 @@ CosKmdSoftAdapter::ProcessHWRenderBuffer(
     }
 }
 
+#if GPUVA
+
+void
+CosKmdSoftAdapter::ProcessGpuVaRenderBuffer(
+    COSDMABUFSUBMISSION *   pDmaBufSubmission)
+{
+    UNREFERENCED_PARAMETER(pDmaBufSubmission);
+
+    // TODO: emulate command buffer submitted with GPU VA from UMD
+}
+
+#endif
+
 BOOLEAN CosKmdSoftAdapter::InterruptRoutine(
     IN_ULONG        MessageNumber)
 {

--- a/compute-only-sample/coskmd/CosKmdSoftAdapter.h
+++ b/compute-only-sample/coskmd/CosKmdSoftAdapter.h
@@ -26,6 +26,11 @@ protected:
 
     virtual void ProcessRenderBuffer(COSDMABUFSUBMISSION * pDmaBufSubmission);
     virtual void ProcessHWRenderBuffer(COSDMABUFSUBMISSION * pDmaBufSubmission);
+#if GPUVA
+
+    virtual void ProcessGpuVaRenderBuffer(COSDMABUFSUBMISSION * pDmaBufSubmission);
+
+#endif
 
     virtual NTSTATUS Start(
         IN_PDXGK_START_INFO     DxgkStartInfo,

--- a/compute-only-sample/cosumd12/CosUmd12.h
+++ b/compute-only-sample/cosumd12/CosUmd12.h
@@ -35,17 +35,35 @@ void UnexpectedDdi(const char * function, const char * file, int line);
 
 #include "CosUmd12Adapter.h"
 #include "CosUmd12Device.h"
+
+#if GPUVA
+#include "CosUmd12CommandQueueGpuVa.h"
+#else
 #include "CosUmd12CommandQueue.h"
+#endif
+
 #include "CosUmd12Heap.h"
 #include "CosUmd12Resource.h"
+
+#if GPUVA
+#include "CosUmd12CommandBufferGpuVa.h"
+#else
 #include "CosUmd12CommandBuffer.h"
+#endif
+
 #include "CosUmd12RootSignature.h"
 #include "CosUmd12Shader.h"
 #include "CosUmd12PipelineState.h"
 #include "CosUmd12Descriptor.h"
 #include "CosUmd12CommandPool.h"
 #include "CosUmd12CommandRecorder.h"
+
+#if GPUVA
+#include "CosUmd12CommandListGpuVa.h"
+#else
 #include "CosUmd12CommandList.h"
+#endif
+
 #include "CosUmd12Fence.h"
 #include "CosUmd12DescriptorHeap.h"
 

--- a/compute-only-sample/cosumd12/CosUmd12CommandBuffer.cpp
+++ b/compute-only-sample/cosumd12/CosUmd12CommandBuffer.cpp
@@ -10,6 +10,8 @@
 
 #include "CosUmd12.h"
 
+#if !GPUVA
+
 CosUmd12CommandBuffer * CosUmd12CommandBuffer::Create()
 {
     UINT size;
@@ -194,3 +196,4 @@ CosUmd12CommandBuffer::Execute(CosUmd12CommandQueue * pCommandQueue)
                             m_patchLocationListPos);
 }
 
+#endif  // !GPUVA

--- a/compute-only-sample/cosumd12/CosUmd12CommandBufferGpuVa.cpp
+++ b/compute-only-sample/cosumd12/CosUmd12CommandBufferGpuVa.cpp
@@ -1,0 +1,147 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Command Buffer implementation using Gpu Va
+//
+// Command Buffer using Gpu Va can be submitted to kernel runtime individually or chained together
+//
+// Copyright (C) Microsoft Corporation
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "CosUmd12.h"
+
+#if GPUVA
+
+CosUmd12CommandBuffer *
+CosUmd12CommandBuffer::Create(
+    CosUmd12Device *    pDevice)
+{
+    D3D12DDIARG_CREATEHEAP_0001 heapDesc;
+
+    heapDesc.ByteSize = COSD_COMMAND_BUFFER_SIZE;
+    heapDesc.Alignment = PAGE_SIZE;
+    heapDesc.MemoryPool = D3D12DDI_MEMORY_POOL_L0;
+    heapDesc.CPUPageProperty = D3D12DDI_CPU_PAGE_PROPERTY_WRITE_COMBINE;
+    heapDesc.Flags = D3D12DDI_HEAP_FLAG_BUFFERS;
+    heapDesc.CreationNodeMask = 1;
+    heapDesc.VisibleNodeMask = 1;
+
+    CosUmd12CommandBuffer * pCommandBuffer = new CosUmd12CommandBuffer(pDevice, MAKE_D3D10DDI_HRTRESOURCE(NULL), &heapDesc);
+    if (nullptr == pCommandBuffer)
+    {
+        return nullptr;
+    }
+
+    HRESULT hr;
+
+    hr = pCommandBuffer->Standup();
+    if (FAILED(hr))
+    {
+        delete pCommandBuffer;
+        pCommandBuffer = nullptr;
+    }
+
+    return pCommandBuffer;
+}
+
+CosUmd12CommandBuffer::CosUmd12CommandBuffer(
+    CosUmd12Device *    pDevice,
+    D3D12DDI_HRTRESOURCE    hRTHeap,
+    const D3D12DDIARG_CREATEHEAP_0001 * pHeapDesc) :
+    m_commandHeap(pDevice, hRTHeap, pHeapDesc)
+{
+    m_pCommandBuffer = NULL;
+    m_commandBufferSize = (UINT)pHeapDesc->ByteSize;
+
+    m_commandBufferPos = 0;
+}
+
+HRESULT CosUmd12CommandBuffer::Standup()
+{
+    HRESULT hr;
+
+    hr = m_commandHeap.Standup();
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    hr = m_commandHeap.Map((void **)&m_pCommandBuffer);
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    //
+    // Write header into command buffer (for KMD)
+    //
+
+    m_pCmdBufHeader = (GpuCommand *)m_pCommandBuffer;
+    m_pCmdBufHeader->m_commandId = Header;
+    m_pCmdBufHeader->m_commandBufferHeader.m_swCommandBuffer = 0;
+    m_pCmdBufHeader->m_commandBufferHeader.m_gpuVaCommandBuffer = 1;
+
+    m_commandBufferPos += sizeof(GpuCommand);
+
+    return hr;
+}
+
+void CosUmd12CommandBuffer::Teardown()
+{
+    m_commandHeap.Teardown();
+}
+
+CosUmd12CommandBuffer::~CosUmd12CommandBuffer()
+{
+    Teardown();
+
+    free(this);
+}
+
+bool CosUmd12CommandBuffer::IsCommandBufferEmpty()
+{
+    return (m_commandBufferPos <= sizeof(GpuCommand));
+}
+
+void
+CosUmd12CommandBuffer::ReserveCommandBufferSpace(
+    UINT                        commandSize,
+    BYTE **                     ppCommandBuffer)
+{
+    *ppCommandBuffer = NULL;
+
+    if ((m_commandBufferPos + commandSize + COMMAND_BUFFER_FLUSH_THRESHOLD) > m_commandBufferSize)
+    {
+        return;
+    }
+
+    *ppCommandBuffer = m_pCommandBuffer + m_commandBufferPos;
+}
+
+void
+CosUmd12CommandBuffer::CommitCommandBufferSpace(
+    UINT    commandSize)
+{
+    // Update the command buffer position
+    m_commandBufferPos += commandSize;
+    assert((m_commandBufferPos + COMMAND_BUFFER_FLUSH_THRESHOLD) < m_commandBufferSize);
+}
+
+HRESULT
+CosUmd12CommandBuffer::Execute(CosUmd12CommandQueue * pCommandQueue)
+{
+    if (IsCommandBufferEmpty())
+    {
+        return S_OK;
+    }
+
+    return pCommandQueue->ExecuteCommandBuffer(
+                            m_commandHeap.GetGpuVa(),
+                            m_commandBufferPos,
+                            m_pCommandBuffer);
+
+    return S_OK;
+}
+
+#endif  // GPUVA
+

--- a/compute-only-sample/cosumd12/CosUmd12CommandBufferGpuVa.h
+++ b/compute-only-sample/cosumd12/CosUmd12CommandBufferGpuVa.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "CosUmd12.h"
+
+class CosUmd12CommandBuffer
+{
+public:
+    static CosUmd12CommandBuffer * Create(
+        CosUmd12Device *    pDevice);
+
+    CosUmd12CommandBuffer(
+        CosUmd12Device *                    pDevice,
+        D3D12DDI_HRTRESOURCE                hRTHeap,
+        const D3D12DDIARG_CREATEHEAP_0001 * pHeapDesc);
+
+    ~CosUmd12CommandBuffer();
+
+    HRESULT Standup();
+    void Teardown();
+
+    void
+    ReserveCommandBufferSpace(
+        UINT                        commandSize,
+        BYTE **                     ppCommandBuffer);
+
+    void
+    CommitCommandBufferSpace(
+        UINT    commandSize);
+
+    bool IsCommandBufferEmpty();
+
+    // Interface for Command Queue
+    HRESULT Execute(CosUmd12CommandQueue * pCommandQueue);
+
+private:
+
+    CosUmd12Heap                        m_commandHeap;
+
+    BYTE *                              m_pCommandBuffer;
+    UINT                                m_commandBufferSize;
+    UINT                                m_commandBufferPos;
+
+    GpuCommand *                        m_pCmdBufHeader;
+
+    CONST UINT  COMMAND_BUFFER_FLUSH_THRESHOLD = 512;
+};

--- a/compute-only-sample/cosumd12/CosUmd12CommandListGpuVa.h
+++ b/compute-only-sample/cosumd12/CosUmd12CommandListGpuVa.h
@@ -1,0 +1,183 @@
+#pragma once
+
+#include "CosUmd12.h"
+
+class CosUmd12DescriptorHeap;
+
+const UINT COS_MAX_NUM_COMMAND_BUFFERS = 256;
+
+class CosUmd12CommandList
+{
+public:
+    explicit CosUmd12CommandList(CosUmd12Device* pDevice, const D3D12DDIARG_CREATE_COMMAND_LIST_0040* pArgs, D3D12DDI_HRTCOMMANDLIST rtCommandList)
+    {
+        m_pDevice = pDevice;
+        m_args = *pArgs;
+        m_rtCommandList = rtCommandList;
+        m_pPipelineState = NULL;
+        memset(m_pDescriptorHeaps, 0, sizeof(m_pDescriptorHeaps));
+        m_pCommandPool = NULL;
+        m_numFilledCommandBuffers = 0;
+    }
+
+    ~CosUmd12CommandList()
+    {
+    }
+
+    void Reset(const D3D12DDIARG_RESETCOMMANDLIST_0040 * pReset);
+
+    static int CalculateSize(const D3D12DDIARG_CREATE_COMMAND_LIST_0040 * pArgs)
+    {
+        return sizeof(CosUmd12CommandList);
+    }
+
+    HRESULT StandUp();
+
+    void SetPipelineState(CosUmd12PipelineState * pPipelineState)
+    {
+        m_pPipelineState = pPipelineState;
+    }
+
+    bool IsComputeType() { return (m_args.QueueFlags & D3D12DDI_COMMAND_QUEUE_FLAG_3D) == 0; }
+    bool IsRenderType() { return (m_args.QueueFlags & D3D12DDI_COMMAND_QUEUE_FLAG_3D) != 0; }
+
+    static CosUmd12CommandList* CastFrom(D3D12DDI_HCOMMANDLIST);
+    D3D12DDI_HCOMMANDLIST CastTo() const;
+
+    void Close();
+
+    void SetRootSignature(
+        D3D12DDI_HROOTSIGNATURE rootSignature);
+
+    void SetDescriptorHeaps(
+        UINT numDescriptorHeaps,
+        D3D12DDI_HDESCRIPTORHEAP * pDescriptorHeaps);
+
+    void SetRootDescriptorTable(
+        UINT rootParameterIndex,
+        D3D12DDI_GPU_DESCRIPTOR_HANDLE baseDescriptor);
+
+    void SetRoot32BitConstants(
+        UINT rootParameterIndex,
+        UINT num32BitValuesToSet,
+        const void* pSrcData,
+        UINT destOffsetIn32BitValues);
+
+    void SetRootView(
+        UINT RootParameterIndex,
+        D3D12DDI_GPU_VIRTUAL_ADDRESS BufferLocation);
+
+    void Dispatch(
+        UINT ThreadGroupCountX,
+        UINT ThreadGroupCountY,
+        UINT ThreadGroupCountZ);
+
+    void ResourceCopy(D3D12DDI_HRESOURCE DstResource, D3D12DDI_HRESOURCE SrcResource);
+    void CopyBufferRegion(D3D12DDIARG_BUFFER_PLACEMENT& dst, D3D12DDIARG_BUFFER_PLACEMENT& src, UINT64 bytesToCopy);
+    void GpuMemoryCopy(D3D12_GPU_VIRTUAL_ADDRESS dstGpuVa, D3D12_GPU_VIRTUAL_ADDRESS srcGpuVa, UINT size);
+
+    template <typename THwMetaCommand, typename THwIoTable>
+    void ExecuteMlMetaCommand(THwMetaCommand * pHwMetaCommand, THwIoTable * pHwIoTable, MetaCommandId metaCommandId)
+    {
+        UINT numHwDescriptors = sizeof(THwIoTable) / sizeof(D3D12_GPU_DESCRIPTOR_HANDLE);
+        UINT commandSize = sizeof(GpuHwMetaCommand) + sizeof(THwMetaCommand) + numHwDescriptors * sizeof(GpuHWDescriptor);
+
+        BYTE * pCommandBuf;
+
+        ReserveCommandBufferSpace(
+            commandSize,
+            (BYTE **)&pCommandBuf);
+        if (NULL == pCommandBuf)
+        {
+            return;
+        }
+
+        GpuHwMetaCommand *  pMetaCommand = (GpuHwMetaCommand *)pCommandBuf;
+
+        pMetaCommand->m_commandId = MetaCommandExecute;
+        pMetaCommand->m_commandSize = commandSize;
+
+        pMetaCommand->m_metaCommandId = metaCommandId;
+
+        // Copy the meta command META_COMMAND_CREATE_*_DESC
+        memcpy(pMetaCommand + 1, pHwMetaCommand, sizeof(THwMetaCommand));
+
+        // Clear the resource descriptors
+        GpuHWDescriptor *   pHwDescriptors = (GpuHWDescriptor *)(pCommandBuf + sizeof(GpuHwMetaCommand) + sizeof(THwMetaCommand));
+        memset(pHwDescriptors, 0, numHwDescriptors * sizeof(GpuHWDescriptor));
+
+        //
+        // TODO : Create allocation for Descriptor Heap
+        //
+
+        //
+        // Copy the resource descriptors into the command buffer
+        //
+        // For ML Meta Command, all resources are referenced by their (UAV) descriptors'
+        // D3D12_GPU_DESCRIPTOR_HANDLE(GPU VA) (within the descriptor heap) directly.
+        //
+        // For HW with GPU VA support, this should be a simple copy of META_COMMAND_EXECUTE_*_DESC
+        //
+        //
+
+        D3D12_GPU_DESCRIPTOR_HANDLE *   pGpuDescriptorHandle = (D3D12_GPU_DESCRIPTOR_HANDLE *)pHwIoTable;
+        CosUmd12DescriptorHeap *        pUavHeap = m_pDescriptorHeaps[D3D12DDI_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV];
+        UINT                            i;
+
+        for (i = 0; i < numHwDescriptors; i++, pGpuDescriptorHandle++, pHwDescriptors++)
+        {
+            if (pGpuDescriptorHandle->ptr)
+            {
+                UINT descriptorIndex = (UINT)((pGpuDescriptorHandle->ptr -
+                    pUavHeap->GetGpuAddress())) / sizeof(CosUmd12Descriptor);
+
+                CosUmd12Descriptor * pDescriptor = pUavHeap->GetCpuAddress() + descriptorIndex;
+
+                pDescriptor->WriteHWDescriptor(pHwDescriptors);
+            }
+        }
+
+        // Commit the command into command buffer
+        m_pCurCommandBuffer->CommitCommandBufferSpace(commandSize);
+    }
+
+    // Interface for Command Queue
+    void Execute(CosUmd12CommandQueue * pCommandQueue);
+
+private:
+
+    CosUmd12Device * m_pDevice;
+    D3D12DDIARG_CREATE_COMMAND_LIST_0040 m_args;
+    D3D12DDI_HRTCOMMANDLIST m_rtCommandList;
+    CosUmd12PipelineState * m_pPipelineState;
+    CosUmd12DescriptorHeap * m_pDescriptorHeaps[D3D12DDI_DESCRIPTOR_HEAP_TYPE_NUM_TYPES];
+
+    //
+    // Storage for current root values specified by Root Signature
+    //
+
+    BYTE m_rootValues[SIZE_ROOT_SIGNATURE];
+
+    CosUmd12CommandPool * m_pCommandPool;
+
+    CosUmd12CommandBuffer * m_pCurCommandBuffer;
+
+    UINT m_numFilledCommandBuffers;
+    CosUmd12CommandBuffer * m_filledCommandBuffers[COS_MAX_NUM_COMMAND_BUFFERS];
+
+    void
+    ReserveCommandBufferSpace(
+        UINT                        commandSize,
+        BYTE **                     ppCommandBuffer);
+};
+
+inline CosUmd12CommandList* CosUmd12CommandList::CastFrom(D3D12DDI_HCOMMANDLIST hRootSignature)
+{
+    return static_cast< CosUmd12CommandList* >(hRootSignature.pDrvPrivate);
+}
+
+inline D3D12DDI_HCOMMANDLIST CosUmd12CommandList::CastTo() const
+{
+    // TODO: Why does MAKE_D3D10DDI_HDEPTHSTENCILSTATE not exist?
+    return MAKE_D3D12DDI_HCOMMANDLIST(const_cast< CosUmd12CommandList* >(this));
+}

--- a/compute-only-sample/cosumd12/CosUmd12CommandPool.cpp
+++ b/compute-only-sample/cosumd12/CosUmd12CommandPool.cpp
@@ -16,7 +16,15 @@ CosUmd12CommandBuffer *
 CosUmd12CommandPool::AcquireCommandBuffer(
     D3D12DDI_COMMAND_QUEUE_FLAGS queueFlags)
 {
+#if GPUVA
+
+    return CosUmd12CommandBuffer::Create(m_pDevice);
+
+#else
+
     return CosUmd12CommandBuffer::Create();
+
+#endif
 }
 
 void

--- a/compute-only-sample/cosumd12/CosUmd12CommandQueueGpuVa.h
+++ b/compute-only-sample/cosumd12/CosUmd12CommandQueueGpuVa.h
@@ -1,0 +1,59 @@
+#pragma once
+
+class CosUmd12Device;
+
+class CosUmd12CommandQueue
+{
+public:
+    explicit CosUmd12CommandQueue(CosUmd12Device* pDevice, D3D12DDI_HRTCOMMANDQUEUE hRTCommandQueue, const D3D12DDIARG_CREATECOMMANDQUEUE_0050* pArgs)
+    {
+        m_pDevice = pDevice;
+        m_args = *pArgs;
+        m_hRTCommandQueue = hRTCommandQueue;
+    }
+
+    ~CosUmd12CommandQueue()
+    {
+    }
+
+    static int CalculateSize(const D3D12DDIARG_CREATECOMMANDQUEUE_0050 * pArgs)
+    {
+        return sizeof(CosUmd12CommandQueue);
+    }
+
+    static CosUmd12CommandQueue* CastFrom(D3D12DDI_HCOMMANDQUEUE);
+    D3D12DDI_HCOMMANDQUEUE CastTo() const;
+
+    HRESULT Standup();
+    void Teardown();
+
+    // Ddi ExecuteCommandLists support
+    void ExecuteCommandLists(UINT Count, const D3D12DDI_HCOMMANDLIST* pCommandLists);
+
+    // Interface for Command List
+    HRESULT
+    ExecuteCommandBuffer(
+        D3DGPU_VIRTUAL_ADDRESS  commandBufferGpuVa,
+        UINT                    commandBufferLength,
+        BYTE *                  pCommandBuffer);
+
+private:
+
+    CosUmd12Device * m_pDevice;
+    D3D12DDIARG_CREATECOMMANDQUEUE_0050 m_args;
+    D3D12DDI_HRTCOMMANDQUEUE m_hRTCommandQueue;
+
+    D3DDDICB_CREATECONTEXTVIRTUAL m_createContext;
+};
+
+inline CosUmd12CommandQueue* CosUmd12CommandQueue::CastFrom(D3D12DDI_HCOMMANDQUEUE hRootSignature)
+{
+    return static_cast< CosUmd12CommandQueue* >(hRootSignature.pDrvPrivate);
+}
+
+inline D3D12DDI_HCOMMANDQUEUE CosUmd12CommandQueue::CastTo() const
+{
+    // TODO: Why does MAKE_D3D10DDI_HDEPTHSTENCILSTATE not exist?
+    return MAKE_D3D12DDI_HCOMMANDQUEUE(const_cast< CosUmd12CommandQueue* >(this));
+}
+

--- a/compute-only-sample/cosumd12/CosUmd12Descriptor.cpp
+++ b/compute-only-sample/cosumd12/CosUmd12Descriptor.cpp
@@ -8,6 +8,48 @@
 
 #include "CosUmd12.h"
 
+#if GPUVA
+
+void CosUmd12Descriptor::WriteHWDescriptor(
+    GpuHWDescriptor *   pHwDescriptor) const
+{
+    D3D12DDI_GPU_VIRTUAL_ADDRESS resourceGpuVa;
+    UINT allocationOffset = 0;
+    CosUmd12Resource * pResource = NULL;
+
+    switch (m_type)
+    {
+    case COS_CBV:
+        resourceGpuVa = m_cbv.BufferLocation;
+        break;
+    case COS_SRV:
+        ASSERT(false);
+        break;
+    case COS_UAV:
+        //
+        // TODO : Support Counter resource for Append structured buffer
+        //
+        pResource = CosUmd12Resource::CastFrom(m_uav.hDrvResource);
+        resourceGpuVa = pResource->GetGpuVa();
+        switch (m_uav.ResourceDimension)
+        {
+        case D3D12DDI_RD_BUFFER:
+            resourceGpuVa += (m_uav.Buffer.FirstElement * m_uav.Buffer.StructureByteStride);
+            break;
+        case D3D12DDI_RD_TEXTURE1D:
+        case D3D12DDI_RD_TEXTURE2D:
+        case D3D12DDI_RD_TEXTURE3D:
+            ASSERT(false);
+            break;
+        }
+        break;
+    }
+
+    pHwDescriptor->m_resourceGpuAddress.QuadPart = resourceGpuVa;
+}
+
+#endif
+
 void CosUmd12Descriptor::WriteHWDescriptor(
     CosUmd12CommandBuffer * pCurCommandBuffer,
     UINT hwDescriptorOffset,
@@ -65,6 +107,8 @@ void CosUmd12Descriptor::WriteHWDescriptor(
         break;
     }
 
+#if !GPUVA
+
     D3DKMT_HANDLE hAllocation = (D3DKMT_HANDLE)(resourceGpuVA >> 32);
     allocationOffset += (UINT)(resourceGpuVA & 0xFFFFFFFF);
 
@@ -76,5 +120,7 @@ void CosUmd12Descriptor::WriteHWDescriptor(
                         hwDescriptorOffset,
                         0,
                         allocationOffset);
+
+#endif
 }
 

--- a/compute-only-sample/cosumd12/CosUmd12Descriptor.h
+++ b/compute-only-sample/cosumd12/CosUmd12Descriptor.h
@@ -31,6 +31,13 @@ public:
         m_uav = *pDesc;
     }
 
+#if GPUVA
+
+    void WriteHWDescriptor(
+        GpuHWDescriptor *   pHwDescriptor) const;
+
+#endif
+
     void WriteHWDescriptor(
         CosUmd12CommandBuffer * pCurCommandBuffer,
         UINT hwDescriptorOffset,

--- a/compute-only-sample/cosumd12/CosUmd12Device.cpp
+++ b/compute-only-sample/cosumd12/CosUmd12Device.cpp
@@ -27,16 +27,48 @@ CosUmd12Device::CosUmd12Device(
     assert(pArgs->hDrvDevice.pDrvPrivate == (void *) this);
 
     assert(m_Interface == D3D12DDI_INTERFACE_VERSION_R5);
+
+#if GPUVA
+
+    m_latestPagingFenceValue = 0L;
+
+#endif
 }
 
 void CosUmd12Device::Standup()
 {
+#if GPUVA
+
+    HRESULT hr;
+
+    memset(&m_pagingQueueDesc, 0, sizeof(m_pagingQueueDesc));
+
+    m_pagingQueueDesc.Priority = D3DDDI_PAGINGQUEUE_PRIORITY_NORMAL;
+
+    hr = m_pKMCallbacks->pfnCreatePagingQueueCb(m_hRTDevice.handle, &m_pagingQueueDesc);
+    if (FAILED(hr))
+    {
+        m_pUMCallbacks->pfnSetErrorCb(m_hRTDevice, D3DDDIERR_DEVICEREMOVED);
+    }
+
+#endif
+
     m_curUniqueAddress = 0x100000000;
+
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------
 void CosUmd12Device::Teardown()
 {
+#if GPUVA
+
+    D3DDDI_DESTROYPAGINGQUEUE destroyPagingQueue = {};
+
+    destroyPagingQueue.hPagingQueue = m_pagingQueueDesc.hPagingQueue;
+
+    m_pKMCallbacks->pfnDestroyPagingQueueCb(m_hRTDevice.handle, &destroyPagingQueue);
+
+#endif
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------
@@ -44,6 +76,42 @@ CosUmd12Device::~CosUmd12Device()
 {
     // do nothing
 }
+
+#if GPUVA
+
+void CosUmd12Device::TrackPagingFence(
+    UINT64  newPagingFenceValue)
+{
+    if (newPagingFenceValue <= m_latestPagingFenceValue)
+    {
+        return;
+    }
+
+    m_latestPagingFenceValue = newPagingFenceValue;
+}
+
+void CosUmd12Device::WaitForPagingOperation(
+    HANDLE  hContext)
+{
+    if ((*((UINT *)m_pagingQueueDesc.FenceValueCPUVirtualAddress)) >= m_latestPagingFenceValue)
+    {
+        return;
+    }
+
+    HRESULT hr;
+
+    D3DDDICB_WAITFORSYNCHRONIZATIONOBJECTFROMGPU    waitFromGpu = { 0 };
+
+    waitFromGpu.hContext = hContext;
+    waitFromGpu.ObjectCount = 1;
+    waitFromGpu.ObjectHandleArray = &m_pagingQueueDesc.hSyncObject;
+    waitFromGpu.MonitoredFenceValueArray = &m_latestPagingFenceValue;
+
+    hr = m_pKMCallbacks->pfnWaitForSynchronizationObjectFromGpuCb(m_hRTDevice.handle, &waitFromGpu);
+    ASSERT(S_OK == hr);
+}
+
+#endif
 
 D3D12DDI_GPU_VIRTUAL_ADDRESS CosUmd12Device::AllocateUniqueAddress(UINT size)
 {

--- a/compute-only-sample/cosumd12/CosUmd12Device.h
+++ b/compute-only-sample/cosumd12/CosUmd12Device.h
@@ -63,6 +63,13 @@ public:
 
     static D3D12DDIARG_META_COMMAND_DESC m_supportedMetaCommandDescs[];
 
+#if GPUVA
+
+    void TrackPagingFence(UINT64 newPagingFenceValue);
+    void WaitForPagingOperation(HANDLE hContext);
+
+#endif
+
 public:
 
     CosUmd12Adapter*                m_pAdapter;
@@ -72,7 +79,15 @@ public:
     const D3D12DDI_CORELAYER_DEVICECALLBACKS_0050*   m_pUMCallbacks;
     const D3DDDI_DEVICECALLBACKS*   m_pKMCallbacks;
 
+#if GPUVA
+
+    D3DDDICB_CREATEPAGINGQUEUE      m_pagingQueueDesc;
+    UINT64                          m_latestPagingFenceValue;
+
+#endif
+
     D3D12DDI_GPU_VIRTUAL_ADDRESS    m_curUniqueAddress;
+
 };
 
 inline CosUmd12Device* CosUmd12Device::CastFrom(D3D10DDI_HDEVICE hDevice)

--- a/compute-only-sample/cosumd12/CosUmd12DeviceDDI.cpp
+++ b/compute-only-sample/cosumd12/CosUmd12DeviceDDI.cpp
@@ -338,6 +338,7 @@ HRESULT APIENTRY CosUmd12Device_Ddi_CreateCommandQueue_0050(
     TRACE_FUNCTION();
 
     CosUmd12Device * pDevice = CosUmd12Device::CastFrom(Device);
+
     CosUmd12CommandQueue * pCommandQueue = new (DrvCommandQueue.pDrvPrivate) CosUmd12CommandQueue(pDevice, RTCommandQueue, pDesc);
 
     return pCommandQueue->Standup();
@@ -1106,7 +1107,15 @@ D3D12DDI_GPU_VIRTUAL_ADDRESS APIENTRY CosUmd12Device_Ddi_CheckResourceVirtualAdd
 
     CosUmd12Resource * pResource = (CosUmd12Resource *)Resource.pDrvPrivate;
 
+#if GPUVA
+
+    return pResource->GetGpuVa();
+
+#else
+
     return pResource->GetUniqueAddress();
+
+#endif
 }
 
 void APIENTRY CosUmd12Device_Ddi_CheckResourceAllocationInfo_0022(

--- a/compute-only-sample/cosumd12/CosUmd12Heap.h
+++ b/compute-only-sample/cosumd12/CosUmd12Heap.h
@@ -42,6 +42,15 @@ public:
     HRESULT Map(void** pHeapData);
     void Unmap();
 
+#if GPUVA
+
+    D3D12DDI_GPU_VIRTUAL_ADDRESS GetGpuVa()
+    {
+        return m_gpuVa;
+    }
+
+#endif
+
     D3DKMT_HANDLE GetAllocationHandle()
     {
         return m_hKMAllocation;
@@ -58,7 +67,16 @@ private:
     D3DKMT_HANDLE m_hKMAllocation;
     BYTE * m_pCpuAddress;
 
+#if GPUVA
+
+    D3D12DDI_GPU_VIRTUAL_ADDRESS m_gpuVa;
+    UINT64 m_pagingFenceValue;
+
+#else
+
     D3D12DDI_GPU_VIRTUAL_ADDRESS m_uniqueAddress;
+
+#endif
 };
 
 inline CosUmd12Heap* CosUmd12Heap::CastFrom(D3D12DDI_HHEAP hHeap)

--- a/compute-only-sample/cosumd12/CosUmd12Resource.cpp
+++ b/compute-only-sample/cosumd12/CosUmd12Resource.cpp
@@ -19,7 +19,17 @@ CosUmd12Resource::Standup(CosUmd12Heap * pHeap)
     return S_OK;
 }
 
+#if GPUVA
+
+D3D12DDI_GPU_VIRTUAL_ADDRESS CosUmd12Resource::GetGpuVa()
+{
+    return m_pHeap->GetGpuVa() + m_desc.ReuseBufferGPUVA.BaseAddress.UMD.Offset;
+}
+
+#endif
+
 D3D12DDI_GPU_VIRTUAL_ADDRESS CosUmd12Resource::GetUniqueAddress()
 {
     return (((D3D12DDI_GPU_VIRTUAL_ADDRESS)m_pHeap->GetAllocationHandle()) << 32) | m_desc.ReuseBufferGPUVA.BaseAddress.UMD.Offset;
 }
+

--- a/compute-only-sample/cosumd12/CosUmd12Resource.h
+++ b/compute-only-sample/cosumd12/CosUmd12Resource.h
@@ -84,6 +84,8 @@ public:
         return m_pHeap->m_hKMAllocation;
     }
 
+    D3D12DDI_GPU_VIRTUAL_ADDRESS GetGpuVa();
+
 private:
 
     static const int kMagic = 'rsrc';

--- a/compute-only-sample/cosumd12/CosUmd12RootSignature.cpp
+++ b/compute-only-sample/cosumd12/CosUmd12RootSignature.cpp
@@ -177,6 +177,9 @@ void CosUmd12RootSignature::WriteHWRootDescriptor(
     UINT hwDescriptorOffset,
     D3DDDI_PATCHLOCATIONLIST * &pPatchLocations)
 {
+#if GPUVA
+#else
+
     D3DKMT_HANDLE hAllocation = (D3DKMT_HANDLE)(resourceGpuVA >> 32);
     UINT allocationOffset = (UINT)(resourceGpuVA & 0xFFFFFFFF);
 
@@ -188,6 +191,8 @@ void CosUmd12RootSignature::WriteHWRootDescriptor(
                         hwDescriptorOffset,
                         0,
                         allocationOffset);
+
+#endif
 }
 
 void CosUmd12RootSignature::WriteHWRootSignature(

--- a/compute-only-sample/cosumd12/cosumd12.vcxproj
+++ b/compute-only-sample/cosumd12/cosumd12.vcxproj
@@ -141,7 +141,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>MLMC=0;_DEBUG;COSUMD12_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MLMC=0;GPUVA=0;_DEBUG;COSUMD12_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/std:c++17 %(AdditionalOptions)</AdditionalOptions>
@@ -247,9 +247,12 @@
     <ClInclude Include="CosUmd12.h" />
     <ClInclude Include="CosUmd12Adapter.h" />
     <ClInclude Include="CosUmd12CommandBuffer.h" />
+    <ClInclude Include="CosUmd12CommandBufferGpuVa.h" />
     <ClInclude Include="CosUmd12CommandList.h" />
+    <ClInclude Include="CosUmd12CommandListGpuVa.h" />
     <ClInclude Include="CosUmd12CommandPool.h" />
     <ClInclude Include="CosUmd12CommandQueue.h" />
+    <ClInclude Include="CosUmd12CommandQueueGpuVa.h" />
     <ClInclude Include="CosUmd12CommandRecorder.h" />
     <ClInclude Include="CosUmd12DescriptorHeap.h" />
     <ClInclude Include="CosUmd12Device.h" />
@@ -270,10 +273,13 @@
     </ClCompile>
     <ClCompile Include="CosUmd12Adapter.cpp" />
     <ClCompile Include="CosUmd12CommandBuffer.cpp" />
+    <ClCompile Include="CosUmd12CommandBufferGpuVa.cpp" />
     <ClCompile Include="CosUmd12CommandList.cpp" />
+    <ClCompile Include="CosUmd12CommandListGpuVa.cpp" />
     <ClCompile Include="CosUmd12CommandPool.cpp" />
     <ClCompile Include="CosUmd12CommandQueue.cpp" />
     <ClCompile Include="CosUmd12CommandQueueDdi.cpp" />
+    <ClCompile Include="CosUmd12CommandQueueGpuVa.cpp" />
     <ClCompile Include="CosUmd12ComputeCommandListDdi.cpp" />
     <ClCompile Include="CosUmd12Descriptor.cpp" />
     <ClCompile Include="CosUmd12DescriptorHeap.cpp" />

--- a/compute-only-sample/cosumd12/cosumd12.vcxproj.filters
+++ b/compute-only-sample/cosumd12/cosumd12.vcxproj.filters
@@ -66,6 +66,15 @@
     <ClInclude Include="CosUmd12MetaCommand.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CosUmd12CommandQueueGpuVa.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CosUmd12CommandBufferGpuVa.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CosUmd12CommandListGpuVa.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CosUmd12.cpp">
@@ -120,6 +129,15 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="CosUmd12ComputeCommandListDdi.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CosUmd12CommandQueueGpuVa.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CosUmd12CommandBufferGpuVa.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CosUmd12CommandListGpuVa.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
The taregt is to support GPU VA using only system memory
The current support is partial for Meta Command and CopyResource.

The major work is finished for GPU VA support in:
KMD QueryAdapterInfo, BuildPagingBuffer, SubmitCommandVirtual, etc
UMD12 Command Queue/List/Buffer

Support GPU VA in Descriptor Heap, Root Signature and Shader dispatch requires mode work.
Support GPU VA with local video memory segment will require some work.