### PR TITLE
Update cos.inf to make the compute driver to belong to the ComputeAccelerator class

### DIFF
--- a/compute-only-sample/cosdriver/cos.inf
+++ b/compute-only-sample/cosdriver/cos.inf
@@ -14,8 +14,8 @@
 
 [Version]
 Signature = "$Windows NT$"
-Class=Display
-ClassGuid={4D36E968-E325-11CE-BFC1-08002BE10318}
+Class=ComputeAccelerator
+ClassGuid={F01A9D53-3FF6-48D2-9F97-C8A7004BE10C}
 Provider=%ManufacturerName%
 CatalogFile=coskmd.cat
 


### PR DESCRIPTION
There is a dedicated device class for compute accelerators - ComputeAccelerator, which the driver should use.